### PR TITLE
Fix footer categories

### DIFF
--- a/src/actions/userActions.js
+++ b/src/actions/userActions.js
@@ -40,7 +40,7 @@ export const login = (email, password) => async (dispatch) => {
     };
 
     const { data } = await axios.post(
-      "/users/login",
+      "/api/users/login",
       { email, password },
       config
     );

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Container, Row, Col } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
 
@@ -6,6 +6,38 @@ const Footer = () => {
   const linkStyle = {
     color: 'white',
     textDecoration: 'none'
+  };
+
+  const [categories, setCategories] = useState([]);
+
+  useEffect(() => {
+    const fetchCategories = async () => {
+      try {
+        const response = await fetch('http://localhost:5678/api/categories');
+        const data = await response.json();
+        setCategories(data.categories || []);
+      } catch (err) {
+        console.error('Error fetching categories:', err);
+        setCategories([]);
+      }
+    };
+    fetchCategories();
+  }, []);
+
+  const getIconClass = (category) => {
+    let icon = 'fas fa-folder me-2';
+    if (typeof category === 'string') {
+      if (category.includes('Laptop')) icon = 'fas fa-laptop me-2';
+      else if (category.includes('Desktop') || category.includes('PC')) icon = 'fas fa-desktop me-2';
+      else if (category.includes('Components')) icon = 'fas fa-microchip me-2';
+      else if (category.includes('Accessories')) icon = 'fas fa-headphones me-2';
+      else if (category.includes('Monitor')) icon = 'fas fa-tv me-2';
+      else if (category.includes('Gaming')) icon = 'fas fa-gamepad me-2';
+      else if (category.includes('Networking')) icon = 'fas fa-network-wired me-2';
+      else if (category.includes('Software')) icon = 'fas fa-compact-disc me-2';
+      else if (category.includes('Workstation')) icon = 'fas fa-server me-2';
+    }
+    return icon;
   };
 
   return (
@@ -38,18 +70,17 @@ const Footer = () => {
           <Col md={2} className="mb-4">
             <h5 className="text-white mb-3">Danh Mục</h5>
             <ul className="list-unstyled">
-              <li className="mb-2">
-                <Link to="/products?category=laptop" style={linkStyle}>Laptop</Link>
-              </li>
-              <li className="mb-2">
-                <Link to="/products?category=desktop" style={linkStyle}>Desktop</Link>
-              </li>
-              <li className="mb-2">
-                <Link to="/products?category=accessories" style={linkStyle}>Phụ Kiện</Link>
-              </li>
-              <li className="mb-2">
-                <Link to="/products?category=components" style={linkStyle}>Linh Kiện</Link>
-              </li>
+              {categories.map((cat, idx) => (
+                <li className="mb-2" key={idx}>
+                  <Link
+                    to={`/products?category=${encodeURIComponent(cat)}`}
+                    style={linkStyle}
+                  >
+                    <i className={getIconClass(cat)}></i>
+                    {cat}
+                  </Link>
+                </li>
+              ))}
             </ul>
           </Col>
           

--- a/src/components/layout/Footer.jsx
+++ b/src/components/layout/Footer.jsx
@@ -1,10 +1,42 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Container, Row, Col } from 'react-bootstrap';
 
 const Footer = () => {
   const linkStyle = {
     color: 'white',
     textDecoration: 'none'
+  };
+
+  const [categories, setCategories] = useState([]);
+
+  useEffect(() => {
+    const fetchCategories = async () => {
+      try {
+        const response = await fetch('http://localhost:5678/api/categories');
+        const data = await response.json();
+        setCategories(data.categories || []);
+      } catch (err) {
+        console.error('Error fetching categories:', err);
+        setCategories([]);
+      }
+    };
+    fetchCategories();
+  }, []);
+
+  const getIconClass = (category) => {
+    let icon = 'fas fa-folder me-2';
+    if (typeof category === 'string') {
+      if (category.includes('Laptop')) icon = 'fas fa-laptop me-2';
+      else if (category.includes('Desktop') || category.includes('PC')) icon = 'fas fa-desktop me-2';
+      else if (category.includes('Components')) icon = 'fas fa-microchip me-2';
+      else if (category.includes('Accessories')) icon = 'fas fa-headphones me-2';
+      else if (category.includes('Monitor')) icon = 'fas fa-tv me-2';
+      else if (category.includes('Gaming')) icon = 'fas fa-gamepad me-2';
+      else if (category.includes('Networking')) icon = 'fas fa-network-wired me-2';
+      else if (category.includes('Software')) icon = 'fas fa-compact-disc me-2';
+      else if (category.includes('Workstation')) icon = 'fas fa-server me-2';
+    }
+    return icon;
   };
 
   return (
@@ -37,18 +69,17 @@ const Footer = () => {
           <Col md={2} className="mb-4">
             <h5 className="text-white mb-3">Danh Mục</h5>
             <ul className="list-unstyled">
-              <li className="mb-2">
-                <a href="/products?category=laptop" style={linkStyle}><i className="fas fa-laptop me-2"></i>Laptop</a>
-              </li>
-              <li className="mb-2">
-                <a href="/products?category=desktop" style={linkStyle}><i className="fas fa-desktop me-2"></i>Desktop</a>
-              </li>
-              <li className="mb-2">
-                <a href="/products?category=accessories" style={linkStyle}><i className="fas fa-headphones me-2"></i>Phụ Kiện</a>
-              </li>
-              <li className="mb-2">
-                <a href="/products?category=components" style={linkStyle}><i className="fas fa-microchip me-2"></i>Linh Kiện</a>
-              </li>
+              {categories.map((cat, idx) => (
+                <li className="mb-2" key={idx}>
+                  <a
+                    href={`/products?category=${encodeURIComponent(cat)}`}
+                    style={linkStyle}
+                  >
+                    <i className={getIconClass(cat)}></i>
+                    {cat}
+                  </a>
+                </li>
+              ))}
             </ul>
           </Col>
           


### PR DESCRIPTION
## Summary
- fetch categories from API in both footer components
- display categories dynamically instead of static list

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842f0f070a0832ca0d32bed183838df